### PR TITLE
Error handling

### DIFF
--- a/unshorten.js
+++ b/unshorten.js
@@ -19,7 +19,14 @@
 				function(response) {
 					(callback || console.log)(response.headers.location || url);
 				}
-			).end();
+			).on( 'error', function( err ) {
+				if( 'getaddrinfo ENOTFOUND' === err.message ) {
+					console.log(url +' cannot be resolved.');
+				}
+				else {
+					console.log(err.stack);
+				}
+			}).end();
 		} else {
 			console.error('Not a valid URL: ' + url);
 			(callback || console.log)(url);


### PR DESCRIPTION
Hello Mathias!

I have been using node-unshorten for a couple of weeks to parse urls on my twitter feed. But I keep getting every now and then some domains that cannot be properly resolved ( human error, DNS issue, ... ) and the request throws an error.

Anyway, as there is no error handler, my whole application crashes, restarts automatically and tries to unshorten the same faulty url until my twitter limit is hit. So I've basically added one for these cases while I'm strengthening other parts of my application.

Here's one example of a faulty url: http://alturl.com/5d4pq ( it seems to be a DNS issue, so it actually might work properly for you ), but any non existing domain will probably cause the same issue.

If you're interested I can open a pull request.

Cheers,

Velan.
