### PR TITLE
set 'agent': false - disable connection pooling

### DIFF
--- a/unshorten.js
+++ b/unshorten.js
@@ -14,7 +14,8 @@
 				{
 					'method': 'HEAD',
 					'host': host,
-					'path': path
+					'path': path,
+					'agent': false
 				},
 				function(response) {
 					(callback || console.log)(response.headers.location || url);


### PR DESCRIPTION
When wrapped in a forEach, I could only process 5/6 urls at a time due to the issues described here:
http://stackoverflow.com/questions/12060869/why-is-node-js-only-processing-six-requests-at-a-time

setting 'agent': false removes connection pooling, and removes this issue
