### PR TITLE
Modernization overhaul (a few fixes and some requests)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/README.md
+++ b/README.md
@@ -1,31 +1,42 @@
 # Unshorten
 
-A simple URL unshortener for [Node.js](http://nodejs.org/).
+A simple URL unshortener for [Node.js](https://nodejs.org/).
 
 ## Example usage
 
 ```js
-var unshorten = require('./unshorten.js');
-unshorten('http://mths.be/unshorten', function(url) {
-	console.log(url + ' is where it’s at!');
+const unshorten = require("./unshorten.js");
+unshorten('https://mths.be/unshorten', function(url) {
+	console.log(url, "is where it's at!");
 });
 ```
 
-…or, via [npm](http://npmjs.org/):
+...or, via [npm](https://npmjs.org/):
 
 ```bash
 npm install unshorten
 ```
 
-…and then:
+...and then:
 
 ~~~ js
-var unshorten = require('unshorten');
-unshorten('http://mths.be/unshorten', function(url) {
-	console.log(url + ' is where it’s at!');
+const unshorten = require("unshorten");
+unshorten('https://mths.be/unshorten', function(url) {
+	console.log(url, "is where it's at!");
 });
 ~~~
 
+...or as a command-line tool:
+
+```bash
+# install it:
+npm install --global unshorten
+# then run it:
+unshorten https://mths.be/unshorten
+# you can even pass it multiple URLs at once:
+unshorten https://mths.be/unshorten http://youtu.be
+```
+
 ## Credits
 
-Made for fun (and to get more familiar with Node) by [Mathias](http://mathiasbynens.be/).
+Made for fun (and to get more familiar with Node) by [Mathias](https://mathiasbynens.be/).

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
 	"description": "A simple URL unshortener.",
 	"homepage": "http://mths.be/unshorten",
 	"main": "unshorten.js",
+	"bin": {
+		"unshorten": "./unshorten-exec.js"
+	},
 	"keywords": [
 		"url",
 		"unshorten",
@@ -20,7 +23,7 @@
 		"type": "git",
 		"url": "https://github.com/mathiasbynens/node-unshorten.git"
 	},
-	"engines": [
-		"node"
-	]
+	"engines": {
+		"node": ">=6.4.0"
+	}
 }

--- a/unshorten-exec.js
+++ b/unshorten-exec.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+{
+  const unshorten = require('./unshorten');
+  const [,, ...paths] = process.argv;
+
+  if (paths.length) {
+    paths.forEach(path => unshorten(path));
+  } else {
+    console.error("URL not provided.");
+  }
+}


### PR DESCRIPTION
A couple notes:
• If this PR is accepted, the version number will certainly need to be changed.
• This PR brings the project into incompatibility with Node versions _below_ v6.4.0. I can backpedal the modern syntax if @mathiasbynens wants to continue targeting older versions of Node.

Big changes:
• Modernized to ES2015+ patterns.
• Added CLI support (per @mathiasbynens via https://github.com/mathiasbynens/node-unshorten/issues/2 -- but man pages still need to be added, which can be done via package.json and linked doc files, though there are some helpful packages to improve the experience: meow (or commander) and chalk, et al.).
• CLI supports multiple URLs. This was added to support convention and because looping in Bash is not as trivial as it is in JavaScript.
• Disabled connection pooling (per @alexjamesbrown via https://github.com/mathiasbynens/node-unshorten/pull/5).
• Added more error handling (per @Velan via https://github.com/mathiasbynens/node-unshorten/pull/3).
• Made very minor readability improvements, but I generally tried to keep the style consistent with @mathiasbynens' original style.
